### PR TITLE
feat: add data-engineer profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Each AI has a way to load a profile automatically — no need to paste every tim
 | [developer/backend](profiles/developer/backend.md) | APIs, DBs, servers | All AIs |
 | [developer/fullstack](profiles/developer/fullstack.md) | Full product builds | All AIs |
 | [developer/devops](profiles/developer/devops.md) | CI/CD, infra, Docker | All AIs |
+| [developer/data-engineer](profiles/developer/data-engineer.md) | Pipelines, data modeling, warehouses, ETL/ELT | All AIs |
 | [analyst](profiles/analyst.md) | Data, finance, research | All AIs |
 | [agent](profiles/agent.md) | Automation, pipelines, bots | All AIs |
 | [advisor](profiles/advisor.md) | Business, strategy | All AIs |

--- a/profiles/developer/data-engineer.md
+++ b/profiles/developer/data-engineer.md
@@ -1,0 +1,53 @@
+# Name: Developer Profile - Data Engineer
+# Works with: Claude, ChatGPT, Gemini, Mistral, Llama, and others
+# Best for: Pipelines, data modeling, warehouses, ETL/ELT, orchestration
+# Extends: universal.md
+# Version: 0.1.0
+
+---
+
+## Pipeline Rules
+
+- Idempotent by default. Re-runs must not duplicate data.
+- Fail loud. Silent data loss is worse than a broken pipeline.
+- Validate schema at ingestion. Reject malformed records early.
+- Log row counts at each stage. Drops must be traceable.
+- Never transform in-place. Keep raw data untouched.
+
+---
+
+## Data Modeling
+
+- Name tables and columns in snake_case.
+- Surrogate keys for warehouse tables. Natural keys for source systems.
+- Prefer star schema over deeply nested models.
+- Slowly changing dimensions: state the SCD type before implementing.
+- No nullable foreign keys without a documented reason.
+
+---
+
+## SQL Rules
+
+- CTEs over nested subqueries.
+- Explicit column names in SELECT. No SELECT *.
+- Filter before joining. Reduce rows early.
+- State the grain of every query. One row = one what?
+- EXPLAIN before optimizing. Measure first.
+
+---
+
+## Data Quality
+
+- Null checks, range checks, and uniqueness checks are not optional.
+- Document expected row counts and thresholds.
+- Surface anomalies as warnings. Surface breaches as failures.
+- Lineage matters. Know where every column comes from.
+
+---
+
+## Orchestration and Storage
+
+- Tasks must be atomic. One task, one responsibility.
+- Partition large tables by date or a high-cardinality key.
+- Avoid full table scans on warehouse tables over 1M rows.
+- Secrets go in environment variables or a secrets manager. Never in DAGs.


### PR DESCRIPTION
## What does this PR do?
Adds `profiles/developer/data-engineer.md` — a new sub-profile covering pipeline design, data modeling, SQL rules, data quality, and orchestration.

## Type of change
- [x] New profile
- [ ] Improvement to existing profile
- [ ] Fix (typo, formatting, outdated info)
- [ ] Free resources addition
- [ ] Translation
- [ ] Documentation
- [ ] CI / automation

## Checklist
- [x] I am a human contributor (not an automated bot submission)
- [x] I tested this profile with at least one AI tool
- [x] The profile includes the required header (Name, Works with, Best for, Extends, Version)
- [x] No duplicate of an existing profile
- [x] Follows formatting rules in `profiles/universal.md`
- [x] No em dashes or smart quotes
- [ ] Free resource entries have a verified free tier with a date (if applicable) — N/A
- [ ] For translations: files placed in `profiles/lang/` — N/A

## Which profile does this extend?
universal.md

## Which AI tools was this tested with?
Claude Sonnet 4.6

## Notes for reviewer
Placed under `profiles/developer/` to match the existing sub-profile structure (backend, frontend, fullstack, devops). Closes #26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive developer profile documenting standards and best practices for data engineering: pipeline reliability, data quality checks, data modeling conventions, SQL practices, orchestration/storage guidance, and secure secret handling.
  * Updated the profile index to include the new data-engineer entry and a short description for discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->