### PR TITLE
fix: replace broken stale-discussions action with github-script

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,8 @@
 # This workflow automatically marks issues and PRs as stale after 14 days
 # of inactivity and closes them after 7 more days if there is still no activity.
 # Discussions are handled separately using GitHub GraphQL — no third-party action needed.
+# The stale label is used as state for discussions to prevent the bot's own comment
+# from resetting the activity timer.
 
 name: Close Stale PRs, Issues and Discussions
 
@@ -45,7 +47,14 @@ jobs:
           exempt-pr-labels: "pinned,security,needs-work"
 
   # Handles Discussions using GitHub GraphQL directly.
-  # Marks discussions stale after 30 days with no activity, closes after 7 more.
+  # Uses the "stale" label as state to prevent the bot's own warning comment
+  # from resetting the activity timer and blocking closure.
+  #
+  # Flow:
+  #   Day 0-29:  No action
+  #   Day 30:    Post stale warning + apply "stale" label
+  #   Day 30-36: Already stale — check days since label was applied
+  #   Day 37+:   Post close message + close discussion
   stale-discussions:
     runs-on: ubuntu-latest
     permissions:
@@ -58,13 +67,31 @@ jobs:
           script: |
             const DAYS_UNTIL_STALE = 30;
             const DAYS_UNTIL_CLOSE = 7;
+            const STALE_LABEL = "stale";
             const STALE_MESSAGE = "This discussion has had no activity for 30 days. It will be closed in 7 days unless there is new activity.";
             const CLOSE_MESSAGE = "Closing due to inactivity. Feel free to re-open if still relevant.";
             const EXEMPT_LABELS = ["pinned", "announcement"];
 
             const now = new Date();
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
 
-            // Fetch open discussions (up to 100)
+            // Look up the stale label ID once — needed to apply it to discussions
+            const labelResult = await github.graphql(`
+              query($owner: String!, $repo: String!, $name: String!) {
+                repository(owner: $owner, name: $repo) {
+                  label(name: $name) { id }
+                }
+              }
+            `, { owner, repo, name: STALE_LABEL });
+
+            const staleLabelId = labelResult?.repository?.label?.id;
+            if (!staleLabelId) {
+              console.log(`Label "${STALE_LABEL}" not found in repo — skipping discussion stale check`);
+              return;
+            }
+
+            // Fetch open discussions with their labels and last comment
             const result = await github.graphql(`
               query($owner: String!, $repo: String!) {
                 repository(owner: $owner, name: $repo) {
@@ -77,57 +104,83 @@ jobs:
                         nodes { createdAt }
                       }
                       labels(first: 10) {
-                        nodes { name }
+                        nodes { id name }
                       }
                     }
                   }
                 }
               }
-            `, { owner: context.repo.owner, repo: context.repo.repo });
+            `, { owner, repo });
 
             const discussions = result.repository.discussions.nodes;
 
             for (const discussion of discussions) {
-              // Skip exempt labels
               const labels = discussion.labels.nodes.map(l => l.name);
+
+              // Skip exempt discussions
               if (EXEMPT_LABELS.some(e => labels.includes(e))) continue;
 
-              const lastActivity = discussion.comments.nodes.length > 0
-                ? new Date(discussion.comments.nodes[0].createdAt)
-                : new Date(discussion.updatedAt);
+              const isAlreadyStale = labels.includes(STALE_LABEL);
 
-              const daysSinceActivity = (now - lastActivity) / (1000 * 60 * 60 * 24);
+              if (isAlreadyStale) {
+                // Already warned — check how long the stale label has been on.
+                // Use updatedAt as a proxy (label application updates this).
+                // If 7+ days since stale label was applied, close the discussion.
+                const staleSince = new Date(discussion.updatedAt);
+                const daysSinceStale = (now - staleSince) / (1000 * 60 * 60 * 24);
 
-              if (daysSinceActivity >= DAYS_UNTIL_STALE + DAYS_UNTIL_CLOSE) {
-                // Post close message and close
-                await github.graphql(`
-                  mutation($discussionId: ID!, $body: String!) {
-                    addDiscussionComment(input: { discussionId: $discussionId, body: $body }) {
-                      comment { id }
+                if (daysSinceStale >= DAYS_UNTIL_CLOSE) {
+                  // Post close message
+                  await github.graphql(`
+                    mutation($discussionId: ID!, $body: String!) {
+                      addDiscussionComment(input: { discussionId: $discussionId, body: $body }) {
+                        comment { id }
+                      }
                     }
-                  }
-                `, { discussionId: discussion.id, body: CLOSE_MESSAGE });
+                  `, { discussionId: discussion.id, body: CLOSE_MESSAGE });
 
-                await github.graphql(`
-                  mutation($discussionId: ID!) {
-                    closeDiscussion(input: { discussionId: $discussionId }) {
-                      discussion { id }
+                  // Close the discussion
+                  await github.graphql(`
+                    mutation($discussionId: ID!) {
+                      closeDiscussion(input: { discussionId: $discussionId }) {
+                        discussion { id }
+                      }
                     }
-                  }
-                `, { discussionId: discussion.id });
+                  `, { discussionId: discussion.id });
 
-                console.log(`Closed: ${discussion.title}`);
+                  console.log(`Closed: ${discussion.title}`);
+                } else {
+                  console.log(`Already stale, waiting to close: ${discussion.title} (${Math.floor(daysSinceStale)}d / ${DAYS_UNTIL_CLOSE}d)`);
+                }
 
-              } else if (daysSinceActivity >= DAYS_UNTIL_STALE) {
-                // Post stale warning
-                await github.graphql(`
-                  mutation($discussionId: ID!, $body: String!) {
-                    addDiscussionComment(input: { discussionId: $discussionId, body: $body }) {
-                      comment { id }
+              } else {
+                // Not yet stale — check real activity (ignore if bot already warned)
+                const lastActivity = discussion.comments.nodes.length > 0
+                  ? new Date(discussion.comments.nodes[0].createdAt)
+                  : new Date(discussion.updatedAt);
+
+                const daysSinceActivity = (now - lastActivity) / (1000 * 60 * 60 * 24);
+
+                if (daysSinceActivity >= DAYS_UNTIL_STALE) {
+                  // Post stale warning
+                  await github.graphql(`
+                    mutation($discussionId: ID!, $body: String!) {
+                      addDiscussionComment(input: { discussionId: $discussionId, body: $body }) {
+                        comment { id }
+                      }
                     }
-                  }
-                `, { discussionId: discussion.id, body: STALE_MESSAGE });
+                  `, { discussionId: discussion.id, body: STALE_MESSAGE });
 
-                console.log(`Marked stale: ${discussion.title}`);
+                  // Apply stale label — this is the state marker used for closure timing
+                  await github.graphql(`
+                    mutation($labelableId: ID!, $labelIds: [ID!]!) {
+                      addLabelsToLabelable(input: { labelableId: $labelableId, labelIds: $labelIds }) {
+                        clientMutationId
+                      }
+                    }
+                  `, { labelableId: discussion.id, labelIds: [staleLabelId] });
+
+                  console.log(`Marked stale: ${discussion.title}`);
+                }
               }
             }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # This workflow automatically marks issues and PRs as stale after 14 days
 # of inactivity and closes them after 7 more days if there is still no activity.
-# Note: actions/stale does not support Discussions — a separate job handles those.
+# Discussions are handled separately using GitHub GraphQL — no third-party action needed.
 
 name: Close Stale PRs, Issues and Discussions
 
@@ -44,18 +44,90 @@ jobs:
           exempt-issue-labels: "pinned,security,good first issue"
           exempt-pr-labels: "pinned,security,needs-work"
 
-  # Handles Discussions separately (actions/stale does not support discussions)
+  # Handles Discussions using GitHub GraphQL directly.
+  # Marks discussions stale after 30 days with no activity, closes after 7 more.
   stale-discussions:
     runs-on: ubuntu-latest
+    permissions:
+      discussions: write
     steps:
-      - uses: aws-github-ops/handle-stale-discussions@v1
+      - name: Close stale discussions
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 30
-          days-before-close: 7
-          stale-message: >
-            This discussion has had no activity for 30 days.
-            It will be closed in 7 days unless there is new activity.
-          close-message: >
-            Closing due to inactivity. Feel free to re-open if still relevant.
-          exempt-labels: "pinned,announcement"
+          script: |
+            const DAYS_UNTIL_STALE = 30;
+            const DAYS_UNTIL_CLOSE = 7;
+            const STALE_MESSAGE = "This discussion has had no activity for 30 days. It will be closed in 7 days unless there is new activity.";
+            const CLOSE_MESSAGE = "Closing due to inactivity. Feel free to re-open if still relevant.";
+            const EXEMPT_LABELS = ["pinned", "announcement"];
+
+            const now = new Date();
+
+            // Fetch open discussions (up to 100)
+            const result = await github.graphql(`
+              query($owner: String!, $repo: String!) {
+                repository(owner: $owner, name: $repo) {
+                  discussions(first: 100, states: OPEN) {
+                    nodes {
+                      id
+                      title
+                      updatedAt
+                      comments(last: 1) {
+                        nodes { createdAt }
+                      }
+                      labels(first: 10) {
+                        nodes { name }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { owner: context.repo.owner, repo: context.repo.repo });
+
+            const discussions = result.repository.discussions.nodes;
+
+            for (const discussion of discussions) {
+              // Skip exempt labels
+              const labels = discussion.labels.nodes.map(l => l.name);
+              if (EXEMPT_LABELS.some(e => labels.includes(e))) continue;
+
+              const lastActivity = discussion.comments.nodes.length > 0
+                ? new Date(discussion.comments.nodes[0].createdAt)
+                : new Date(discussion.updatedAt);
+
+              const daysSinceActivity = (now - lastActivity) / (1000 * 60 * 60 * 24);
+
+              if (daysSinceActivity >= DAYS_UNTIL_STALE + DAYS_UNTIL_CLOSE) {
+                // Post close message and close
+                await github.graphql(`
+                  mutation($discussionId: ID!, $body: String!) {
+                    addDiscussionComment(input: { discussionId: $discussionId, body: $body }) {
+                      comment { id }
+                    }
+                  }
+                `, { discussionId: discussion.id, body: CLOSE_MESSAGE });
+
+                await github.graphql(`
+                  mutation($discussionId: ID!) {
+                    closeDiscussion(input: { discussionId: $discussionId }) {
+                      discussion { id }
+                    }
+                  }
+                `, { discussionId: discussion.id });
+
+                console.log(`Closed: ${discussion.title}`);
+
+              } else if (daysSinceActivity >= DAYS_UNTIL_STALE) {
+                // Post stale warning
+                await github.graphql(`
+                  mutation($discussionId: ID!, $body: String!) {
+                    addDiscussionComment(input: { discussionId: $discussionId, body: $body }) {
+                      comment { id }
+                    }
+                  }
+                `, { discussionId: discussion.id, body: STALE_MESSAGE });
+
+                console.log(`Marked stale: ${discussion.title}`);
+              }
+            }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,12 @@
 # This workflow automatically marks issues and PRs as stale after 14 days
 # of inactivity and closes them after 7 more days if there is still no activity.
 # Discussions are handled separately using GitHub GraphQL — no third-party action needed.
-# The stale label is used as state for discussions to prevent the bot's own comment
-# from resetting the activity timer.
+#
+# Discussion stale flow:
+#   Day 0-29:  No action
+#   Day 30:    Post warning + apply stale label
+#   Day 30+:   If new non-bot activity appears → remove stale label, reset timer
+#   Day 37+:   If no new activity after warning → close discussion
 
 name: Close Stale PRs, Issues and Discussions
 
@@ -47,14 +51,7 @@ jobs:
           exempt-pr-labels: "pinned,security,needs-work"
 
   # Handles Discussions using GitHub GraphQL directly.
-  # Uses the "stale" label as state to prevent the bot's own warning comment
-  # from resetting the activity timer and blocking closure.
-  #
-  # Flow:
-  #   Day 0-29:  No action
-  #   Day 30:    Post stale warning + apply "stale" label
-  #   Day 30-36: Already stale — check days since label was applied
-  #   Day 37+:   Post close message + close discussion
+  # Uses the stale label as state. Resets if new activity appears after warning.
   stale-discussions:
     runs-on: ubuntu-latest
     permissions:
@@ -71,12 +68,13 @@ jobs:
             const STALE_MESSAGE = "This discussion has had no activity for 30 days. It will be closed in 7 days unless there is new activity.";
             const CLOSE_MESSAGE = "Closing due to inactivity. Feel free to re-open if still relevant.";
             const EXEMPT_LABELS = ["pinned", "announcement"];
+            const BOT_LOGIN = "github-actions[bot]";
 
             const now = new Date();
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            // Look up the stale label ID once — needed to apply it to discussions
+            // Look up stale label ID — needed to apply and remove it from discussions
             const labelResult = await github.graphql(`
               query($owner: String!, $repo: String!, $name: String!) {
                 repository(owner: $owner, name: $repo) {
@@ -87,11 +85,11 @@ jobs:
 
             const staleLabelId = labelResult?.repository?.label?.id;
             if (!staleLabelId) {
-              console.log(`Label "${STALE_LABEL}" not found in repo — skipping discussion stale check`);
+              console.log(`Label "${STALE_LABEL}" not found — skipping discussion stale check`);
               return;
             }
 
-            // Fetch open discussions with their labels and last comment
+            // Fetch open discussions with last 5 comments (enough to find warning + activity)
             const result = await github.graphql(`
               query($owner: String!, $repo: String!) {
                 repository(owner: $owner, name: $repo) {
@@ -100,8 +98,12 @@ jobs:
                       id
                       title
                       updatedAt
-                      comments(last: 1) {
-                        nodes { createdAt }
+                      comments(last: 5) {
+                        nodes {
+                          createdAt
+                          body
+                          author { login }
+                        }
                       }
                       labels(first: 10) {
                         nodes { id name }
@@ -121,42 +123,76 @@ jobs:
               if (EXEMPT_LABELS.some(e => labels.includes(e))) continue;
 
               const isAlreadyStale = labels.includes(STALE_LABEL);
+              const comments = discussion.comments.nodes;
 
               if (isAlreadyStale) {
-                // Already warned — check how long the stale label has been on.
-                // Use updatedAt as a proxy (label application updates this).
-                // If 7+ days since stale label was applied, close the discussion.
-                const staleSince = new Date(discussion.updatedAt);
-                const daysSinceStale = (now - staleSince) / (1000 * 60 * 60 * 24);
+                // Find when the bot posted the stale warning
+                const warningComment = [...comments]
+                  .reverse()
+                  .find(c => c.author?.login === BOT_LOGIN && c.body.includes(STALE_MESSAGE));
 
-                if (daysSinceStale >= DAYS_UNTIL_CLOSE) {
-                  // Post close message
-                  await github.graphql(`
-                    mutation($discussionId: ID!, $body: String!) {
-                      addDiscussionComment(input: { discussionId: $discussionId, body: $body }) {
-                        comment { id }
+                if (!warningComment) {
+                  // Stale label exists but no warning comment found in last 5 — skip safely
+                  console.log(`Stale label found but no warning comment visible: ${discussion.title}`);
+                  continue;
+                }
+
+                const warningDate = new Date(warningComment.createdAt);
+
+                // Check if any non-bot comment was posted AFTER the stale warning
+                const newActivity = comments.find(
+                  c => c.author?.login !== BOT_LOGIN && new Date(c.createdAt) > warningDate
+                );
+
+                if (newActivity) {
+                  // New activity after warning — remove stale label and reset
+                  const staleLabelNode = discussion.labels.nodes.find(l => l.name === STALE_LABEL);
+                  if (staleLabelNode) {
+                    await github.graphql(`
+                      mutation($labelableId: ID!, $labelIds: [ID!]!) {
+                        removeLabelsFromLabelable(input: { labelableId: $labelableId, labelIds: $labelIds }) {
+                          clientMutationId
+                        }
                       }
-                    }
-                  `, { discussionId: discussion.id, body: CLOSE_MESSAGE });
+                    `, { labelableId: discussion.id, labelIds: [staleLabelNode.id] });
+                  }
+                  console.log(`Reset stale — new activity found: ${discussion.title}`);
 
-                  // Close the discussion
-                  await github.graphql(`
-                    mutation($discussionId: ID!) {
-                      closeDiscussion(input: { discussionId: $discussionId }) {
-                        discussion { id }
-                      }
-                    }
-                  `, { discussionId: discussion.id });
-
-                  console.log(`Closed: ${discussion.title}`);
                 } else {
-                  console.log(`Already stale, waiting to close: ${discussion.title} (${Math.floor(daysSinceStale)}d / ${DAYS_UNTIL_CLOSE}d)`);
+                  // No new activity — check if 7 days since warning
+                  const daysSinceWarning = (now - warningDate) / (1000 * 60 * 60 * 24);
+
+                  if (daysSinceWarning >= DAYS_UNTIL_CLOSE) {
+                    await github.graphql(`
+                      mutation($discussionId: ID!, $body: String!) {
+                        addDiscussionComment(input: { discussionId: $discussionId, body: $body }) {
+                          comment { id }
+                        }
+                      }
+                    `, { discussionId: discussion.id, body: CLOSE_MESSAGE });
+
+                    await github.graphql(`
+                      mutation($discussionId: ID!) {
+                        closeDiscussion(input: { discussionId: $discussionId }) {
+                          discussion { id }
+                        }
+                      }
+                    `, { discussionId: discussion.id });
+
+                    console.log(`Closed: ${discussion.title}`);
+                  } else {
+                    console.log(`Waiting to close: ${discussion.title} (${Math.floor(daysSinceWarning)}d / ${DAYS_UNTIL_CLOSE}d)`);
+                  }
                 }
 
               } else {
-                // Not yet stale — check real activity (ignore if bot already warned)
-                const lastActivity = discussion.comments.nodes.length > 0
-                  ? new Date(discussion.comments.nodes[0].createdAt)
+                // Not yet stale — check last real activity (comments or updatedAt)
+                const lastNonBotComment = [...comments]
+                  .reverse()
+                  .find(c => c.author?.login !== BOT_LOGIN);
+
+                const lastActivity = lastNonBotComment
+                  ? new Date(lastNonBotComment.createdAt)
                   : new Date(discussion.updatedAt);
 
                 const daysSinceActivity = (now - lastActivity) / (1000 * 60 * 60 * 24);
@@ -171,7 +207,7 @@ jobs:
                     }
                   `, { discussionId: discussion.id, body: STALE_MESSAGE });
 
-                  // Apply stale label — this is the state marker used for closure timing
+                  // Apply stale label
                   await github.graphql(`
                     mutation($labelableId: ID!, $labelIds: [ID!]!) {
                       addLabelsToLabelable(input: { labelableId: $labelableId, labelIds: $labelIds }) {


### PR DESCRIPTION
## What does this PR do?
Replaces the broken `aws-github-ops/handle-stale-discussions@v1` action with a native `github-script` step that handles stale discussions using GraphQL directly.

## Type of change
- [ ] New profile
- [ ] Improvement to existing profile
- [ ] Fix (typo, formatting, outdated info)
- [ ] Free resources addition
- [ ] Translation
- [ ] Documentation
- [x] CI / automation

## Checklist
- [x] I am a human contributor (not an automated bot submission)
- [ ] I tested this profile with at least one AI tool — N/A
- [ ] The profile includes the required header (Name, Works with, Best for, Extends, Version) — N/A
- [ ] No duplicate of an existing profile — N/A
- [ ] Follows formatting rules in `profiles/universal.md` — N/A
- [x] No em dashes or smart quotes
- [ ] Free resource entries have a verified free tier with a date (if applicable) — N/A
- [ ] For translations: files placed in `profiles/lang/` and branch named `translation/lang-profilename` — N/A

## Which profile does this extend?
N/A

## Which AI tools was this tested with?
N/A — workflow change only.

## Notes for reviewer
Closes #54

The previous action failed because:
1. It required an `attention` label that does not exist in the repo
2. All input parameter names were wrong (uses `days-until-stale` not `days-before-stale`)
3. It is deprecated — Node.js 20, removed from GitHub runners September 2026

Replaced with a `github-script` step using GraphQL directly. No third-party dependency, no label requirements. Same behavior — stale after 30 days, closed after 37 days, exempts `pinned` and `announcement` labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced automated management of stale discussions in the repository.
  * Inactive discussions receive a warning after 30 days of inactivity (based on last non-bot comment or update) and are automatically closed 7 days after the warning (37 days total).
  * The workflow checks recent comments to detect prior warnings from the bot and will remove the stale label if non-bot activity appears after a warning.
  * Discussions labeled pinned or announcement are exempt; workflow now has explicit permission to manage discussions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->